### PR TITLE
Set up testing on GA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,45 @@
+name: test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.8'
+      - name: Fetch and set up Kowalski
+        uses: actions/checkout@v2
+        with:
+          repository: dmitryduev/kowalski
+          path: kowalski
+      - name: Install Kowalski's dependencies
+        run: |
+          cd kowalski
+          python -m pip install --upgrade pip
+          pip install wheel==0.36.0
+          pip install -r requirements.txt
+      - name: Set up configs
+        run: |
+          cp config.defaults.yaml config.yaml
+          cp docker-compose.defaults.yaml docker-compose.yaml
+      - name: Build and spin up
+        run: |
+          ./kowalski.py build
+          ./kowalski.py up
+      - name: Ingest data into Kowalski and run its tests
+        run: |
+          ./kowalski.py test
+      - name: Install penquins
+        run: |
+          cd ..
+          python setup.py install
+      - name: Run penquins' tests
+        run: |
+          python -m pytest -s tests/test_penquins.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,26 +19,19 @@ jobs:
         with:
           repository: dmitryduev/kowalski
           path: kowalski
-      - name: Install Kowalski's dependencies
+      - name: Configure and spin up Kowalski, ingest test data
         run: |
           cd kowalski
           python -m pip install --upgrade pip
           pip install wheel==0.36.0
           pip install -r requirements.txt
-      - name: Set up configs
-        run: |
           cp config.defaults.yaml config.yaml
           cp docker-compose.defaults.yaml docker-compose.yaml
-      - name: Build and spin up
-        run: |
           ./kowalski.py build
           ./kowalski.py up
-      - name: Ingest data into Kowalski and run its tests
-        run: |
           ./kowalski.py test
       - name: Install penquins
         run: |
-          cd ..
           python setup.py install
       - name: Run penquins' tests
         run: |

--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -15,7 +15,7 @@ import secrets
 import string
 import traceback
 from tqdm.auto import tqdm
-from typing import Union
+from typing import Optional, Union
 
 
 __version__ = "2.0.2"
@@ -24,9 +24,9 @@ __version__ = "2.0.2"
 Num = Union[int, float]
 
 
-DEFAULT_TIMEOUT = 5  # seconds
-DEFAULT_RETRIES = 3
-DEFAULT_BACKOFF_FACTOR = 1
+DEFAULT_TIMEOUT: int = 5  # seconds
+DEFAULT_RETRIES: int = 3
+DEFAULT_BACKOFF_FACTOR: int = 1
 
 
 class TimeoutHTTPAdapter(HTTPAdapter):
@@ -51,9 +51,9 @@ class Kowalski:
 
     def __init__(
         self,
-        username=None,
-        password=None,
-        token=None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        token: Optional[str] = None,
         protocol: str = "https",
         host: str = "kowalski.caltech.edu",
         port: int = 443,

--- a/tests/test_penquins.py
+++ b/tests/test_penquins.py
@@ -1,0 +1,83 @@
+import pytest
+
+from penquins import Kowalski
+
+
+@pytest.fixture(autouse=True, scope="class")
+def kowalski(request):
+    # from Kowalski's default config:
+    username, password, protocol, host, port = (
+        "admin",
+        "admin",
+        "http",
+        "localhost",
+        4000,
+    )
+
+    request.cls.kowalski = Kowalski(
+        username=username, password=password, protocol=protocol, host=host, port=port
+    )
+
+
+class TestPenquins:
+    """
+    Test penquins against a live Kowalski instance running on localhost using the default config
+    Meant to be run on GA CI
+    """
+
+    def test_token_authorization(self):
+        token = self.kowalski.token
+
+        k = Kowalski(token=token, protocol="http", host="localhost", port=4000)
+
+        assert k.ping()
+
+    def test_query_cone_search(self):
+        catalog = "ZTF_alerts"
+        obj_id = "ZTF17aaaaaas"
+
+        query = {
+            "query_type": "cone_search",
+            "query": {
+                "object_coordinates": {
+                    "cone_search_radius": 2,
+                    "cone_search_unit": "arcsec",
+                    "radec": {
+                        obj_id: [
+                            68.578209,
+                            49.0871395,
+                        ]
+                    },
+                },
+                "catalogs": {
+                    catalog: {"filter": {}, "projection": {"_id": 0, "objectId": 1}}
+                },
+            },
+            "kwargs": {"filter_first": False},
+        }
+
+        response = self.kowalski.query(query=query)
+        assert "data" in response
+        data = response.get("data")
+        assert catalog in data
+        assert obj_id in data[catalog]
+        assert len(data[catalog][obj_id]) > 0
+
+    def test_query_find(self):
+        catalog = "ZTF_alerts"
+        obj_id = "ZTF17aaaaaas"
+
+        query = {
+            "query_type": "find",
+            "query": {
+                "catalog": catalog,
+                "filter": {"objectId": obj_id},
+                "projection": {"_id": 0, "objectId": 1},
+            },
+        }
+
+        response = self.kowalski.query(query=query)
+        assert "data" in response
+        data = response.get("data")
+        assert len(data) == 0
+        assert data[0]["objectId"] == obj_id

--- a/tests/test_penquins.py
+++ b/tests/test_penquins.py
@@ -79,5 +79,5 @@ class TestPenquins:
         response = self.kowalski.query(query=query)
         assert "data" in response
         data = response.get("data")
-        assert len(data) == 0
+        assert len(data) > 0
         assert data[0]["objectId"] == obj_id


### PR DESCRIPTION
This PR adds a GitHub Action for testing `penquins` against a live instance of Kowalski running on `localhost` using the default config.