### PR TITLE
Interface for calling any endpoint of Kowalski

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,8 +27,7 @@ jobs:
           pip install -r requirements.txt
           cp config.defaults.yaml config.yaml
           cp docker-compose.defaults.yaml docker-compose.yaml
-          ./kowalski.py build
-          ./kowalski.py up
+          ./kowalski.py up --build
           ./kowalski.py test
       - name: Install penquins
         run: |

--- a/tests/test_penquins.py
+++ b/tests/test_penquins.py
@@ -1,10 +1,11 @@
 import pytest
+import random
 
 from penquins import Kowalski
 
 
 @pytest.fixture(autouse=True, scope="class")
-def kowalski(request):
+def kowalski_fixture(request):
     # from Kowalski's default config:
     username, password, protocol, host, port = (
         "admin",
@@ -17,6 +18,37 @@ def kowalski(request):
     request.cls.kowalski = Kowalski(
         username=username, password=password, protocol=protocol, host=host, port=port
     )
+
+
+@pytest.fixture(autouse=True, scope="class")
+def user_filter_fixture(request):
+    filter_id = random.randint(1, 1000)
+    group_id = random.randint(1, 1000)
+    collection = "ZTF_alerts"
+    permissions = [1, 2]
+    pipeline = [
+        {
+            "$match": {
+                "candidate.drb": {"$gt": 0.9999},
+                "cross_matches.CLU_20190625.0": {"$exists": False},
+            }
+        },
+        {
+            "$addFields": {
+                "annotations.author": "dd",
+                "annotations.mean_rb": {"$avg": "$prv_candidates.rb"},
+            }
+        },
+        {"$project": {"_id": 0, "candid": 1, "objectId": 1, "annotations": 1}},
+    ]
+
+    request.cls.user_filter = {
+        "group_id": group_id,
+        "filter_id": filter_id,
+        "catalog": collection,
+        "permissions": permissions,
+        "pipeline": pipeline,
+    }
 
 
 class TestPenquins:
@@ -81,3 +113,45 @@ class TestPenquins:
         data = response.get("data")
         assert len(data) > 0
         assert data[0]["objectId"] == obj_id
+
+    def test_api_call_filters(self):
+        # post new filter:
+        response = self.kowalski.api(
+            method="post", endpoint="/api/filters", data=self.user_filter
+        )
+        assert response["status"] == "success"
+        assert "data" in response
+        assert "fid" in response["data"]
+        fid1 = response["data"]["fid"]
+
+        # retrieve
+        filter_id = self.user_filter["filter_id"]
+        response = self.kowalski.api(method="get", endpoint=f"/api/filters/{filter_id}")
+        assert response["status"] == "success"
+        assert response["message"] == f"Retrieved filter id {filter_id}"
+        assert "data" in response
+        assert "active_fid" in response["data"]
+        assert response["data"]["active_fid"] == fid1
+        assert "autosave" in response["data"]
+        assert not response["data"]["autosave"]
+
+        # turn update_annotations on
+        response = self.kowalski.api(
+            method="patch",
+            endpoint="/api/filters",
+            data={
+                "filter_id": filter_id,
+                "update_annotations": True,
+            },
+        )
+        assert response["status"] == "success"
+        assert "data" in response
+        assert "update_annotations" in response["data"]
+        assert response["data"]["update_annotations"]
+
+        # delete filter
+        response = self.kowalski.api(
+            method="delete", endpoint=f"/api/filters/{filter_id}"
+        )
+        assert response["status"] == "success"
+        assert response["message"] == f"Removed filter id {filter_id}"


### PR DESCRIPTION
In this PR:

- (Re-)implemented the `Kowalski.api` method for calling any endpoint on Kowalski
- Code clean-up + tests

FIXED::20210204: FIXME::20210203: one test should fail with K's master (the CI builds and spins up a Kowalski instance from master and tests this library against it); should turn green once [kowalki/#71](https://github.com/dmitryduev/kowalski/pull/71) is merged.

TODO::20210203: Release v.2.0.2 once this PR is merged.