### PR TITLE
Add class and function to track all Kowalski instances

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,6 +215,23 @@ queries = [
 responses = kowalski.batch_query(queries=queries, n_treads=4)
 ```
 
+Track and query multiple Kowalski instances at once:
+
+```python
+tokens = {
+    "kowalski": "",
+    "gloria": "",
+    "melman": ""
+ }
+
+instances = construct_instances(tokens=tokens)
+instance = KowalskiInstances(instances=instances)
+
+query = {"query_type": "estimated_document_count",
+         "query": {"catalog": "ZTF_source_classifications_DR5"}}
+query_result = instance.query(query)
+```
+
 ### Interacting with the API
 
 Users can interact with [Kowalski's API](https://kowalski.caltech.edu/docs/api/)


### PR DESCRIPTION
Since the kowalski, gloria and melman machines can each host unique data catalogs, having a way to more seamlessly track these instances would be helpful when querying. This PR adds the `KowalskiInstances` class, which has an `instances` attribute containing a list of Kowalski instances along with helpful methods to query these instances. It also adds the `construct_instances` function that authenticates each instance, either through dictionaries passed into the function or optionally hardcoded tokens/usernames/passwords.