### PR TITLE
Add separate constraints for jd and jdstarthist

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,12 +24,9 @@ jobs:
         run: |
           cd kowalski
           python -m pip install --upgrade pip
-          pip install wheel==0.36.0
-          pip install -r requirements.txt
-          cp config.defaults.yaml config.yaml
           cp docker-compose.defaults.yaml docker-compose.yaml
-          ./kowalski.py up --build
-          ./kowalski.py test
+          make docker_build && make docker_up
+          make docker_test
       - name: Install penquins
         run: |
           python setup.py install

--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -813,8 +813,7 @@ class Kowalski:
             "candidate.programid": {
                 "$in": program_ids
             },
-            # 1 = ZTF Public, 2 = ZTF Public+Partnership, 3 = ZTF Public+Partnership
-            # +Caltech
+            # 1 = ZTF Public, 2 = ZTF Public+Partnership, 3 = ZTF Public+Partnership+Caltech
         }
 
         for k in filter_kwargs.keys():

--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -750,18 +750,18 @@ class Kowalski:
                 return results
 
     def query_skymap(
-            self,
-            path: Path,  # path or file-like object
-            cumprob: float,
-            jd_start: float,
-            jd_end: float,
-            jdstarthist_start: float,
-            jdstarthist_end: float,
-            catalogs: List[str],
-            program_ids: List[int],
-            filter_kwargs: Optional[Mapping] = dict(),
-            projection_kwargs: Optional[Mapping] = dict(),
-            max_n_threads: int = 4,
+        self,
+        path: Path,  # path or file-like object
+        cumprob: float,
+        jd_start: float,
+        jd_end: float,
+        jdstarthist_start: float,
+        jdstarthist_end: float,
+        catalogs: List[str],
+        program_ids: List[int],
+        filter_kwargs: Optional[Mapping] = dict(),
+        projection_kwargs: Optional[Mapping] = dict(),
+        max_n_threads: int = 4,
     ) -> List[dict]:
         """
         Query Kowalski for objects in a skymap

--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -812,8 +812,7 @@ class Kowalski:
             },
             "candidate.programid": {
                 "$in": program_ids
-            },
-            # 1 = ZTF Public, 2 = ZTF Public+Partnership, 3 = ZTF Public+Partnership+Caltech
+            }, # 1 = ZTF Public, 2 = ZTF Public+Partnership, 3 = ZTF Public+Partnership+Caltech
         }
 
         for k in filter_kwargs.keys():

--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -750,17 +750,37 @@ class Kowalski:
                 return results
 
     def query_skymap(
-        self,
-        path: Path,  # path or file-like object
-        cumprob: float,
-        jd_start: float,
-        jd_end: float,
-        catalogs: List[str],
-        program_ids: List[int],
-        filter_kwargs: Optional[Mapping] = dict(),
-        projection_kwargs: Optional[Mapping] = dict(),
-        max_n_threads: int = 4,
+            self,
+            path: Path,  # path or file-like object
+            cumprob: float,
+            jd_start: float,
+            jd_end: float,
+            jdstarthist_start: float,
+            jdstarthist_end: float,
+            catalogs: List[str],
+            program_ids: List[int],
+            filter_kwargs: Optional[Mapping] = dict(),
+            projection_kwargs: Optional[Mapping] = dict(),
+            max_n_threads: int = 4,
     ) -> List[dict]:
+        """
+        Query Kowalski for objects in a skymap
+
+        :param path: path to skymap file
+        :param cumprob: cumulative probability threshold
+        :param jd_start: Query candidates detected after this JD
+        :param jd_end: Query candidates detected before this JD
+        :param jdstarthist_start: Query candidates first detected after this JD
+        (i.e. with jdstarthist > jdstarthist_start). This is to ensure sub-threshold
+        detections that sometimes show up in jdstarthist are also retrieved.
+        :param jdstarthist_end: Query candidates first detected before this JD
+        (i.e. with jdstarthist < jdstarthist_end)
+        :param catalogs: List of catalogs to query
+        :param program_ids: List of program IDs to query
+        :param filter_kwargs: Additional filter kwargs
+        :param projection_kwargs: Additional projection kwargs
+        :param max_n_threads: Maximum number of threads to use
+        """
         missing_args = [
             arg
             for arg in [
@@ -787,16 +807,14 @@ class Kowalski:
         filter = {
             "candidate.jd": {"$gt": jd_start, "$lt": jd_end},
             "candidate.jdstarthist": {
-                "$gt": jd_start,
-                "$lt": jd_end,
-            },
-            "candidate.jdendhist": {
-                "$gt": jd_start,
-                "$lt": jd_end,
+                "$gt": jdstarthist_start,
+                "$lt": jdstarthist_end,
             },
             "candidate.programid": {
                 "$in": program_ids
-            },  # 1 = ZTF Public, 2 = ZTF Public+Partnership, 3 = ZTF Public+Partnership+Caltech
+            },
+            # 1 = ZTF Public, 2 = ZTF Public+Partnership, 3 = ZTF Public+Partnership
+            # +Caltech
         }
 
         for k in filter_kwargs.keys():

--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -812,7 +812,7 @@ class Kowalski:
             },
             "candidate.programid": {
                 "$in": program_ids
-            }, # 1 = ZTF Public, 2 = ZTF Public+Partnership, 3 = ZTF Public+Partnership+Caltech
+            },  # 1 = ZTF Public, 2 = ZTF Public+Partnership, 3 = ZTF Public+Partnership+Caltech
         }
 
         for k in filter_kwargs.keys():

--- a/tests/test_penquins.py
+++ b/tests/test_penquins.py
@@ -378,6 +378,8 @@ class TestPenquins:
         cumprob = 0.7
         jd_start = Time("2019-01-01").jd
         jd_end = Time("2020-01-02").jd
+        jdstarthist_start = jd_start
+        jdstarthist_end = jd_end
         catalogs = ["ZTF_alerts"]
         program_ids = [1]
 
@@ -395,6 +397,8 @@ class TestPenquins:
             cumprob,
             jd_start,
             jd_end,
+            jdstarthist_start,
+            jdstarthist_end,
             catalogs,
             program_ids,
             filter_kwargs,


### PR DESCRIPTION
To ensure that
1. For a given objectId, the latest alert can be retrieved regardless of when it was first detected, making it much easier to get full photometry.
2. Retrieve alerts that have sub-threshold detections within some timespan of the GW event, and are only detected at >5-sigma subsequently.