### PR TITLE
Multiple instance authenticate (username+pwd) bugfix

### DIFF
--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -230,7 +230,7 @@ class Kowalski:
             if cfg.get("token", None) is None:
                 self.instances[name]["username"] = cfg.get("username", None)
                 self.instances[name]["password"] = cfg.get("password", None)
-                self.instances[name]["token"] = self.authenticate()
+                self.instances[name]["token"] = self.authenticate(name)
             else:
                 self.instances[name]["token"] = cfg.get("token", None)
 


### PR DESCRIPTION
@mcoughlin any chance you could push this to pypi? I believe we can use the same version number but just add `.post1` at the end so that its a `post release` and redowloading the same version should use it instead. 
Doing a post release would help not having to update the config of all Kowalski instances.