### PR TITLE
Get instance catalogs: always update list

### DIFF
--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -212,8 +212,7 @@ class Kowalski:
             if len(self.instances) > 1:
                 self.multiple_instances = True
 
-            catalogs = self.get_catalogs(name)
-            self.instances[name]["catalogs"] = catalogs
+            self.get_catalogs(name)  # get catalogs for this instance
 
         except Exception as e:
             del self.instances[name]
@@ -420,7 +419,8 @@ class Kowalski:
             },
         }
         response = self.single_query((query, name))
-        return response[name].get("data")
+        self.instances[name]["catalogs"] = response.get(name, {}).get("data", [])
+        return self.instances[name]["catalogs"]
 
     def get_catalogs_all(self) -> dict:
         catalogs = {}


### PR DESCRIPTION
Instead of setting the list of catalogs of an instance just once when creating the instance, we make sure that the 'get_catalogs' and by extension 'get_all_catalogs' method updates the list every time. 

This makes sure that things stay up to date more easily for whatever implementation that uses penquins.