### PR TITLE
Multi Instance: grab timeout from instance config

### DIFF
--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -174,7 +174,7 @@ class Kowalski:
                 "head": self.instances[name]["session"].head,
             }
             # mount session adapters
-            timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
+            timeout = cfg.get("timeout", kwargs.get("timeout", DEFAULT_TIMEOUT))
             pool_connections = kwargs.get("pool_connections", DEFAULT_POOLSIZE)
             pool_maxsize = kwargs.get("pool_maxsize", DEFAULT_POOLSIZE)
             max_retries = kwargs.get("max_retries", DEFAULT_RETRIES)


### PR DESCRIPTION
The timeout was only read from the Kowalski(..., timeout=60) function arg and not from the multi instances config itself. This PR looks for the timeout from the instance config, then the args/kwargs, and then uses the default.