### PR TITLE
2.4.2 (bugfix: don't ignore `name` for batch queries)

### DIFF
--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -17,7 +17,7 @@ from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from tqdm.auto import tqdm
 
-__version__ = "2.4.1"
+__version__ = "2.4.2"
 
 Num = Union[int, float]
 

--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -577,8 +577,15 @@ class Kowalski:
 
     def prepare_queries(self, queries, name=None) -> dict:
         """Based on the catalogs or catalog specified in the queries, split the queries into multiple queries for each instance"""
-        queries_per_instance = {name: [] for name in self.instances.keys()}
-        instances_load = {name: 0 for name in self.instances.keys()}
+        instances_names = list(self.instances.keys())
+        if name is not None:
+            if name not in instances_names:
+                raise ValueError(
+                    f"Instance {name} not found in the list of instances: {instances_names}"
+                )
+            instances_names = [name]
+        queries_per_instance = {instance_name: [] for instance_name in instances_names}
+        instances_load = {instance_name: 0 for instance_name in instances_names}
         for query in queries:
             query_per_instance, instances_load = self.prepare_query(
                 query, name=name, instances_load=instances_load
@@ -708,7 +715,7 @@ class Kowalski:
                 return results
 
         if queries is not None:
-            queries_split_in_queries = self.prepare_queries(queries)
+            queries_split_in_queries = self.prepare_queries(queries, name=name)
             if len(queries_split_in_queries) == 0:
                 raise ValueError(
                     f"No valid queries found in {str(queries)}\n which yielded {str(queries_split_in_queries)}"

--- a/penquins/penquins.py
+++ b/penquins/penquins.py
@@ -17,7 +17,7 @@ from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from tqdm.auto import tqdm
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 Num = Union[int, float]
 

--- a/readme.md
+++ b/readme.md
@@ -326,7 +326,7 @@ for a detailed guide.
 
 ```shell script
 pip install bumpversion
-export PENQUINS_VERSION=2.4.1
+export PENQUINS_VERSION=2.4.2
 
 bumpversion --current-version $PENQUINS_VERSION minor setup.py penquins/penquins.py
 python setup.py sdist bdist_wheel

--- a/readme.md
+++ b/readme.md
@@ -326,7 +326,7 @@ for a detailed guide.
 
 ```shell script
 pip install bumpversion
-export PENQUINS_VERSION=2.4.0
+export PENQUINS_VERSION=2.4.1
 
 bumpversion --current-version $PENQUINS_VERSION minor setup.py penquins/penquins.py
 python setup.py sdist bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ LICENSE = "MIT"
 URL = "https://github.com/dmitryduev/penquins"
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = "2.4.0"
+VERSION = "2.4.1"
 
 # Indicates if this version is a release version
 RELEASE = "dev" not in VERSION

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ LICENSE = "MIT"
 URL = "https://github.com/dmitryduev/penquins"
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = "2.4.1"
+VERSION = "2.4.2"
 
 # Indicates if this version is a release version
 RELEASE = "dev" not in VERSION


### PR DESCRIPTION
Corrects a bug where the `name` specified when running multiple queries at once was ignored. Updates the version from `2.4.1` -> `2.4.2`